### PR TITLE
callback function returns the disturbing event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ class IdleTracker {
 
     // only evoke callback when value change
     if (this.state.idle) {
-      this.callback({ idle: false });
+      this.callback({ idle: false, event: e });
     }
 
     this.state.idle = false;


### PR DESCRIPTION
Having the information about the event that ended the idle state is often useful.